### PR TITLE
Avoid having isShow as true after handleCancel action

### DIFF
--- a/src/GoodByeProvider.js
+++ b/src/GoodByeProvider.js
@@ -27,19 +27,19 @@ class Provider extends React.Component {
   };
 
   handleOk = () => {
-    this.pass(true);
     this.setState({ isShow: false });
+    this.pass(true);
   };
 
   handleCancel = () => {
-    this.pass(false);
     this.setState({ isShow: false });
+    this.pass(false);
   };
 
   handlePass = bool => {
-    this.pass(bool);
     this.setState({ isShow: false });
-  }
+    this.pass(bool);
+  };
 
   render() {
     const { children } = this.props;


### PR DESCRIPTION
Changing the order of this calls avoids the fact that the isShow can be true after calling handleCancel.

I realized of this using this library on a react-native project, btw this library works with NativeRouter too, and using `Alert.alert` to show the confirmation dialog to the user. The isShow prop and the original call order made it appear 2 times.